### PR TITLE
fix: fix usage with dates

### DIFF
--- a/mysqlpartialdump.py
+++ b/mysqlpartialdump.py
@@ -33,6 +33,8 @@ def info(msg):
 def make_safe(value):
     if value is None:
         return 'NULL'
+    if isinstance(value, datetime):
+        return "'%s'" % value
     if not isinstance(value, basestring):
         return str(value)
     value = value.replace("'", "''").replace("\\", "\\\\")


### PR DESCRIPTION
When using the tool with dates, 
it dumps 
things like

```
(12,'data',2016-01-06 13:56:33),
```

let's quote the date to have 

```
(12,'data','2016-01-06 13:56:33'),
```
